### PR TITLE
Add support for disabling rotation of secrets

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,8 +20,7 @@ jobs:
 
       - name: terraform setup
         uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 0.12.29
+      # with:
       #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
 #     TODO: This step duplicates work done by the Makefile.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# shibd-data-sealer
+# secretsmanager
 
-[![Terraform actions status](https://github.com/techservicesillinois/terraform-aws-shibd-data-sealer/workflows/terraform/badge.svg)](https://github.com/techservicesillinois/terraform-aws-shibd-data-sealer/actions)
+[![Terraform actions status](https://github.com/techservicesillinois/terraform-aws-secretsmanager/workflows/terraform/badge.svg)](https://github.com/techservicesillinois/terraform-aws-secretsmanager/actions)
 
-Provides a [Secret Manager](https://aws.amazon.com/secrets-manager/)
-secret for use with Shibbleth. The secret provided is a base64 encoded
-AES128 key, rotated on a daily basis.
+Provides a [Secrets Manager](https://aws.amazon.com/secrets-manager/)
+secret. A lambda function can optionally be associated with the secret,
+in order to perform periodic secret rotation.
 
 Argument Reference
 -----------------
@@ -12,14 +12,22 @@ Argument Reference
 The following arguments are supported:
 
 * `service` - (Required) The name of the service associated with
-the Shibboleth SP.
+the secret.
 
-* `name` - (Optional) Specifies the friendly name of the new secret.
+* `name` - (Required) Specifies the secret name.
 The secret name can consist of uppercase letters, lowercase letters,
 digits, and any of the following characters: /_+=.@- Spaces are not
-permitted. Default is ${var.service}-shibd-data-sealer.
+permitted. The name stored in SecretsManager will be in the format
+`service/secret_name`.
 
-* `description` - (Optional) A description of the secret.
+* `description` - (Optional) A description of the secret. A reasonable
+default description is provided.
+
+* `automatically_after_days` - (Optional) Specifies the number of
+days between automatic scheduled rotations of the secret. The default
+value is 1. **NOTE: Specifying the value 0 suppresses automatic secret
+rotation.**
+ 
 
 * `kms_key_id` - (Optional) Specifies the ARN or alias of the AWS
 KMS customer master key (CMK) to be used to encrypt the secret
@@ -35,16 +43,12 @@ representing a resource policy.
 * `recovery_window_in_days` - (Optional) Specifies the number of
 days that AWS Secrets Manager waits before it can delete the secret.
 This value can be 0 to force deletion without recovery or range
-from 7 to 30 days. The default value is 0.
+from 7 to 30 days. The default value is 0, meaning that the secret
+can be immediately reused.
 
 * `tags` - (Optional) Specifies a key-value map of user-defined
 tags that are attached to the secret.
 
-* `automatically_after_days` - (Optional) Specifies the number of
-days between automatic scheduled rotations of the secret. The default
-value is 1.
-
- 
 Attributes Reference
 --------------------
 
@@ -52,8 +56,11 @@ The following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of the secret.
 
-* `rotation_enabled ` - Specifies whether automatic rotation is
+* `rotation_enabled` - Specifies whether automatic rotation is
 enabled for this secret.
+
+* `rotation_lambda_arn` - ARN of lambda function used to perform automatic rotation.
+This attribute is omitted if no lambda rotation function is attached to the secret.
 
 Credits
 --------------------

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,10 @@ output "arn" {
   value = aws_secretsmanager_secret.default.arn
 }
 
+output "rotation_lambda_arn" {
+  value = var.automatically_after_days > 0 ? data.aws_lambda_function.selected[0].arn : null
+}
+
 output "rotation_enabled" {
-  value = aws_secretsmanager_secret_rotation.default.rotation_enabled
+  value = var.automatically_after_days > 0 ? aws_secretsmanager_secret_rotation.default[0].rotation_enabled : false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,44 +1,43 @@
-variable "service" {
-  description = "Name of service"
-}
-
-variable "name" {
-  description = "Name of secret"
-  default     = ""
+variable "automatically_after_days" {
+  description = "Number of days between automatic scheduled rotations of the secret"
+  default     = 1
 }
 
 variable "description" {
   description = "Description of the secret"
-  default     = ""
+  default     = null
 }
 
 variable "kms_key_id" {
   description = "AWS KMS customer master key (CMK) to be used to encrypt the secret"
-  default     = ""
+  default     = null
+}
+
+variable "lambda_function_name" {
+  description = "Name of lambda function used by Secrets Manager for key rotation"
+  default     = null
+}
+
+variable "name" {
+  description = "Secret name"
 }
 
 variable "policy" {
-  description = "Filename containing a valid policy document"
-  default     = ""
+  description = "Path of file containing a valid policy document"
+  default     = null
 }
 
 variable "recovery_window_in_days" {
-  description = "Number of days AWS waits before it deletes the secret"
+  description = "Number of days AWS waits before deleting the secret"
   default     = 0
+}
+
+variable "service" {
+  description = "Service name"
 }
 
 variable "tags" {
   description = "User-defined tags attached to the secret"
   type        = map(string)
   default     = {}
-}
-
-variable "automatically_after_days" {
-  description = "Number of days between automatic scheduled rotations of the secret"
-  default     = 1
-}
-
-variable "lambda_function_name" {
-  description = "The name of the lambda function that Secret Manageer will use for key rotation"
-  default     = "aes128-key-rot"
 }


### PR DESCRIPTION
*   The previous iteration of this code did not support SecretsManager secrets with rotation disabled.

*   Cleaned up some code, including using `null` instead of empty string for some default variable declarations.

*   Fixed `rotation_enabled` to accurately report when rotation is enabled.

*   Add `rotation_lambda_arn` to outputs.